### PR TITLE
Update concatenation of pandas DataFrames

### DIFF
--- a/nease/functions.py
+++ b/nease/functions.py
@@ -120,10 +120,10 @@ def affected_edges(nease_data,Join,only_DDIs):
 
 
 
-                    interacting_domains=interacting_domains[['Gene name','NCBI gene ID','Identifier','dPSI','Affected binding (NCBI)']].append(elm_affected, ignore_index=True)
+                    interacting_domains=pd.concat([interacting_domains, elm_affected], ignore_index=True)
 
 
-            
+
             return interacting_domains
     
     


### PR DESCRIPTION
Newer versions of pandas don't allow for row-wise concatenation of dataframes using the `.append` method. This should fix this instance. 

I did not have an example dataset that I could test this on, so I used a dummy set which worked.

I am not aware of any other instances where `.append` was used for dataframes, however I only checked `functions.py`.

